### PR TITLE
Accept bigquery object as a option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ logger.info('Hello World', {
 in order to access bigquery we need a service account credentials, there are 3 ways to set it
 
 1. pass `applicationCredentials` containing a path to your key file in options
-2. set `GOOGLE_APPLICATION_CREDENTIALS` environment settings  
-3. set `SERVICE_ACCOUNT` environment settings (recommended)
+2. pass `bigquery` option that is already initialized
+3. set `GOOGLE_APPLICATION_CREDENTIALS` environment settings
+4. set `SERVICE_ACCOUNT` environment settings (recommended)
 
 the latter was added since adding `GOOGLE_APPLICATION_CREDENTIALS` is reported 
 to sometimes [break other google sdks](https://stackoverflow.com/questions/54711038/firebase-cloud-functions-failed-to-read-credentials-from-file) (such as firebase) 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ interface WinstonBigQueryOptions {
 	dataset: string;
 	table: string;
 	applicationCredentials?: string;
+	bigquery?: BigQuery;
 	schema?: BigQueryTableSchema;
 	create?: boolean;
 	timeout?: number;
@@ -66,13 +67,17 @@ export class WinstonBigQuery extends Transport {
 		const credentialsJsonPath =
 			applicationCredentials || envGoogleAppCred || envServiceAccount;
 
-		if (env.isDevelopment() || env.isTest()) {
-			console.log(`loading credentials from ${credentialsJsonPath}`);
-		}
+		if (options.bigquery) {
+			this.bigquery = options.bigquery;
+		} else {
+			if (env.isDevelopment() || env.isTest()) {
+				console.log(`loading credentials from ${credentialsJsonPath}`);
+			}
 
-		this.bigquery = new BigQuery({
-			keyFile: applicationCredentials
-		});
+			this.bigquery = new BigQuery({
+				keyFile: applicationCredentials
+			});
+		}
 
 		const {create} = this.options;
 


### PR DESCRIPTION
The documented ways of setting up bigquery is difficult for me to use in my environment and I already have a `bigquery` object configured else where in my app. 

By passing in the preconfigured object we open up for other ways of configuring bigquery and also make it more loosly coupled (as in SOLID/dependency inversion principle).