### PR TITLE
accept transport options and pass them on to super constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ type BigQueryTableSchema = {
 	[n: string]: BigQuerySchemaTypes | BigQueryTableSchema;
 };
 
-interface WinstonBigQueryOptions {
+interface WinstonBigQueryOptions extends Transport.TransportStreamOptions {
 	dataset: string;
 	table: string;
 	applicationCredentials?: string;
@@ -36,7 +36,7 @@ export class WinstonBigQuery extends Transport {
 	private isInitialized: boolean;
 
 	constructor(options: WinstonBigQueryOptions) {
-		super();
+		super(options);
 		dotenv.config();
 
 		this.options = _.extend(


### PR DESCRIPTION
The constructor does not accept the options that a transport should. This fixes the type and passes the options on to `super()`.

This, among other things, makes it so we can accept the `format` option.