### PR TITLE
Import missing bigquery type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import Transport from 'winston-transport';
-import {BigQuery} from '@google-cloud/bigquery';
+import {BigQuery, TableMetadata} from '@google-cloud/bigquery';
 import env from './commons/env';
 import {isEmpty, omit} from 'lodash';
 import dotenv from 'dotenv';
@@ -88,12 +88,12 @@ export class WinstonBigQuery extends Transport {
 	async getTableSchema() {
 		const {dataset, table} = this.options;
 
-		const meta: TableMetaData = ((
+		const meta: TableMetadata = (
 			await this.bigquery
 				.dataset(dataset)
 				.table(table)
 				.getMetadata()
-		)[0] as unknown) as TableMetaData;
+		)[0] as unknown;
 
 		const schema = meta.schema.fields.reduce(
 			(


### PR DESCRIPTION
I'm not quite sure about this as I don't understand your types but the code failed to run for me as it can't find the `TableMetaData` type. I import it from `@google-cloud/bigquery` instead of the local file (where it isn't exported?) but as I don't know why it has a local implementation to start with I'm probably missing something.